### PR TITLE
Feature/add travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,8 @@ notifications:
 
 language: node_js
 
+dist: trusty
+
 os:
   - linux
   # - osx

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,38 @@
+notifications:
+  email: false
+
+language: node_js
+
+os:
+  - linux
+  # - osx
+  # - windows
+
+sudo: required
+
+services:
+  - docker
+
+node_js:
+  - '8'
+  - '9'
+  - '10'
+  - '11'
+  - '12'
+
+cache:
+  directories:
+    - $HOME/.npm
+
+before_install:
+  - echo $TRAVIS_BRANCH
+  - echo `git describe --tags --always HEAD`
+  - npm config set progress false
+  - npm config set spin false
+  - npm install
+  - npm run install-deps
+  - docker run -dit --name emscripten -v $(pwd):/src trzeci/emscripten:sdk-incoming-64bit bash
+
+script:
+  - docker exec -it emscripten npm run build
+  - npm test

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,8 +5,8 @@ language: node_js
 
 os:
   - linux
-  - osx
-  - windows
+  # - osx
+  # - windows
 
 sudo: required
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -31,13 +31,8 @@ before_install:
   - npm config set spin false
   - npm install
   - npm run install-deps
-
-  - curl -fsSL https://download.docker.com/linux/ubuntu/gpg | sudo apt-key add -
-  - sudo add-apt-repository "deb [arch=amd64] https://download.docker.com/linux/ubuntu $(lsb_release -cs) stable"
-  - sudo apt-get update
-  - sudo apt-get -y -o Dpkg::Options::="--force-confnew" install docker-ce
   - docker run -dit --name emscripten -v $(pwd):/src trzeci/emscripten:sdk-incoming-64bit bash
 
 script:
-  - docker exec -it emscripten npm run build
+  - npm run build
   - npm test

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,8 +5,8 @@ language: node_js
 
 os:
   - linux
-  # - osx
-  # - windows
+  - osx
+  - windows
 
 sudo: required
 
@@ -14,8 +14,8 @@ services:
   - docker
 
 node_js:
-  - '8'
-  - '9'
+  # - '8'
+  # - '9'
   - '10'
   - '11'
   - '12'

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,8 +3,6 @@ notifications:
 
 language: node_js
 
-dist: trusty
-
 os:
   - linux
   # - osx
@@ -33,6 +31,11 @@ before_install:
   - npm config set spin false
   - npm install
   - npm run install-deps
+
+  - curl -fsSL https://download.docker.com/linux/ubuntu/gpg | sudo apt-key add -
+  - sudo add-apt-repository "deb [arch=amd64] https://download.docker.com/linux/ubuntu $(lsb_release -cs) stable"
+  - sudo apt-get update
+  - sudo apt-get -y -o Dpkg::Options::="--force-confnew" install docker-ce
   - docker run -dit --name emscripten -v $(pwd):/src trzeci/emscripten:sdk-incoming-64bit bash
 
 script:

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ npm install easy-exif
 const { exif } = require('easy-exif')
 const fs = require('fs').promises
 
-const buf = await fs.readFileSync('./samples/crosa.jpg')
+const buf = await fs.readFile('./samples/crosa.jpg')
 console.log(await exif(buf))
 ```
 

--- a/README.md
+++ b/README.md
@@ -20,9 +20,9 @@ npm install easy-exif
 
 ```js
 const { exif } = require('easy-exif')
-const fs = require('fs').promises
+const fs = require('fs')
 
-const buf = await fs.readFile('./samples/crosa.jpg')
+const buf = fs.readFileSync('./samples/crosa.jpg')
 console.log(await exif(buf))
 ```
 

--- a/build.sh
+++ b/build.sh
@@ -4,6 +4,8 @@ set -e
 
 export OPTIMIZE="-O3"
 
+mkdir -p dist
+
 echo "1/1 compiling tiny-exif"
 (
   emcc \


### PR DESCRIPTION
- disable travis on windows and os x for now (osx doesn't support services.docker , windows can't run linux image)
- disable node 8 and 9 (tests are failing) for now